### PR TITLE
Add the -fork flag to submit PRs from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,43 +66,52 @@ Usage: patch2pr [options] [patch]
 
 Options:
 
-  -base-branch=branch  The branch to target with the pull request. If unset,
-                       use the repository's default branch.
+  -base-branch=branch    The branch to target with the pull request. If unset,
+                         use the repository's default branch.
 
-  -draft               Create a draft pull request.
+  -draft                 Create a draft pull request.
 
-  -force               Update the head branch even if it exists and is not a
-                       fast-forward.
+  -force                 Update the head branch even if it exists and is not a
+                         fast-forward.
 
-  -head-branch=branch  The branch to create or update with the new commit. If
-                       unset, use 'patch2pr'.
+  -fork                  Submit the pull request from a fork instead of pushing
+                         directly to the repository. With no other flags, use a
+                         fork in the current account with the same name as the
+                         target repository, creating the fork if it does not exist.
 
-  -json                Output information about the new commit and pull request
-                       in JSON format.
+  -fork-repository=repo  Submit the pull request from the named fork instead of
+                         pushing directly to the repository, creating the fork
+                         if it does not exist. Implies the -fork flag.
 
-  -message=message     Message for the commit. Overrides the patch header.
+  -head-branch=branch    The branch to create or update with the new commit. If
+                         unset, use 'patch2pr'.
 
-  -no-pull-request     Do not create a pull request after creating a commit.
+  -json                  Output information about the new commit and pull request
+                         in JSON format.
 
-  -patch-base=base     Base commit to apply the patch to. Can be a SHA1, a
-                       branch, or a tag. Branches and tags must start with
-                       'refs/heads/' or 'refs/tags/' respectively. If unset,
-                       use the repository's default branch.
+  -message=message       Message for the commit. Overrides the patch header.
 
-  -pull-body=body      The body for the pull request. If unset, use the body of
-                       the commit message.
+  -no-pull-request       Do not create a pull request after creating a commit.
 
-  -pull-title=title    The title for the pull request. If unset, use the title
-                       of the commit message.
+  -patch-base=base       Base commit to apply the patch to. Can be a SHA1, a
+                         branch, or a tag. Branches and tags must start with
+                         'refs/heads/' or 'refs/tags/' respectively. If unset,
+                         use the repository's default branch.
 
-  -repository=repo     Repository to apply the patch to in 'owner/name' format.
-                       Required.
+  -pull-body=body        The body for the pull request. If unset, use the body of
+                         the commit message.
 
-  -token=token         GitHub API token with 'repo' scope for authentication.
-                       If unset, use the value of the GITHUB_TOKEN environment
-                       variable.
+  -pull-title=title      The title for the pull request. If unset, use the title
+                         of the commit message.
 
-  -url=url             GitHub API URL. If unset, use https://api.github.com.
+  -repository=repo       Repository to apply the patch to in 'owner/name' format.
+                         Required.
+
+  -token=token           GitHub API token with 'repo' scope for authentication.
+                         If unset, use the value of the GITHUB_TOKEN environment
+                         variable.
+
+  -url=url               GitHub API URL. If unset, use https://api.github.com.
 ```
 
 ## Usage: Library

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Usage: patch2pr [options] [patch]
 
   Override the commit message by using the -message flag.
 
+  With the -fork and -fork-repository flags, the command can submit the pull
+  request from a fork repository. If an existing fork does not exist, the
+  command creates a new fork, which may take up to five minutes.
+
 Options:
 
   -base-branch=branch    The branch to target with the pull request. If unset,

--- a/cmd/patch2pr/main.go
+++ b/cmd/patch2pr/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -22,6 +23,18 @@ import (
 
 func die(code int, err error) {
 	fmt.Fprintln(os.Stderr, "error:", err)
+
+	var rerr *github.ErrorResponse
+	if errors.As(err, &rerr) && rerr.Response.StatusCode == http.StatusNotFound {
+		fmt.Fprint(os.Stderr, `
+This may be because the repository does not exit or the token you are using
+does not have write permission. If submitting a patch to a repository where you
+do not have write access, consider using the -fork flag to submit the patch
+from a fork.
+`,
+		)
+	}
+
 	os.Exit(code)
 }
 

--- a/cmd/patch2pr/main.go
+++ b/cmd/patch2pr/main.go
@@ -26,7 +26,7 @@ func die(code int, err error) {
 
 	if isNotFound(err) {
 		fmt.Fprint(os.Stderr, `
-This may be because the repository does not exit or the token you are using
+This may be because the repository does not exist or the token you are using
 does not have write permission. If submitting a patch to a repository where you
 do not have write access, consider using the -fork flag to submit the patch
 from a fork.
@@ -87,9 +87,6 @@ func main() {
 		}
 		die(2, err)
 	}
-
-	fmt.Println("fork:", opts.Fork)
-	fmt.Println("fork-repository:", opts.ForkRepository)
 
 	if opts.Repository == nil {
 		die(2, errors.New("the -repository flag is required"))

--- a/cmd/patch2pr/main.go
+++ b/cmd/patch2pr/main.go
@@ -39,19 +39,21 @@ from a fork.
 }
 
 type Options struct {
-	BaseBranch    string
-	Draft         bool
-	Force         bool
-	HeadBranch    string
-	OutputJSON    bool
-	Message       string
-	NoPullRequest bool
-	PatchBase     string
-	PullTitle     string
-	Repository    *patch2pr.Repository
-	GitHubToken   string
-	GitHubURL     *url.URL
-	PullBody      string
+	BaseBranch     string
+	Draft          bool
+	Force          bool
+	Fork           bool
+	ForkRepository *patch2pr.Repository
+	HeadBranch     string
+	OutputJSON     bool
+	Message        string
+	NoPullRequest  bool
+	PatchBase      string
+	PullTitle      string
+	Repository     *patch2pr.Repository
+	GitHubToken    string
+	GitHubURL      *url.URL
+	PullBody       string
 }
 
 func main() {
@@ -66,6 +68,8 @@ func main() {
 	fs.StringVar(&opts.BaseBranch, "base-branch", "", "base-branch")
 	fs.BoolVar(&opts.Draft, "draft", false, "draft")
 	fs.BoolVar(&opts.Force, "force", false, "force")
+	fs.BoolVar(&opts.Fork, "fork", false, "fork")
+	fs.Var(ForkValue{RepositoryValue{&opts.ForkRepository}, &opts.Fork}, "fork-repository", "fork-repository")
 	fs.StringVar(&opts.HeadBranch, "head-branch", "patch2pr", "head-branch")
 	fs.BoolVar(&opts.OutputJSON, "json", false, "json")
 	fs.StringVar(&opts.Message, "message", "", "message")
@@ -84,6 +88,9 @@ func main() {
 		}
 		die(2, err)
 	}
+
+	fmt.Println("fork:", opts.Fork)
+	fmt.Println("fork-repository:", opts.ForkRepository)
 
 	if opts.Repository == nil {
 		die(2, errors.New("the -repository flag is required"))
@@ -358,43 +365,52 @@ Usage: patch2pr [options] [patch]
 
 Options:
 
-  -base-branch=branch  The branch to target with the pull request. If unset,
-                       use the repository's default branch.
+  -base-branch=branch    The branch to target with the pull request. If unset,
+                         use the repository's default branch.
 
-  -draft               Create a draft pull request.
+  -draft                 Create a draft pull request.
 
-  -force               Update the head branch even if it exists and is not a
-                       fast-forward.
+  -force                 Update the head branch even if it exists and is not a
+                         fast-forward.
 
-  -head-branch=branch  The branch to create or update with the new commit. If
-                       unset, use 'patch2pr'.
+  -fork                  Submit the pull request from a fork instead of pushing
+                         directly to the repository. With no other flags, use a
+                         fork in the current account with the same name as the
+                         target repository, creating the fork if it does not exist.
 
-  -json                Output information about the new commit and pull request
-                       in JSON format.
+  -fork-repository=repo  Submit the pull request from the named fork instead of
+                         pushing directly to the repository, creating the fork
+                         if it does not exist. Implies the -fork flag.
 
-  -message=message     Message for the commit. Overrides the patch header.
+  -head-branch=branch    The branch to create or update with the new commit. If
+                         unset, use 'patch2pr'.
 
-  -no-pull-request     Do not create a pull request after creating a commit.
+  -json                  Output information about the new commit and pull request
+                         in JSON format.
 
-  -patch-base=base     Base commit to apply the patch to. Can be a SHA1, a
-                       branch, or a tag. Branches and tags must start with
-                       'refs/heads/' or 'refs/tags/' respectively. If unset,
-                       use the repository's default branch.
+  -message=message       Message for the commit. Overrides the patch header.
 
-  -pull-body=body      The body for the pull request. If unset, use the body of
-                       the commit message.
+  -no-pull-request       Do not create a pull request after creating a commit.
 
-  -pull-title=title    The title for the pull request. If unset, use the title
-                       of the commit message.
+  -patch-base=base       Base commit to apply the patch to. Can be a SHA1, a
+                         branch, or a tag. Branches and tags must start with
+                         'refs/heads/' or 'refs/tags/' respectively. If unset,
+                         use the repository's default branch.
 
-  -repository=repo     Repository to apply the patch to in 'owner/name' format.
-                       Required.
+  -pull-body=body        The body for the pull request. If unset, use the body of
+                         the commit message.
 
-  -token=token         GitHub API token with 'repo' scope for authentication.
-                       If unset, use the value of the GITHUB_TOKEN environment
-                       variable.
+  -pull-title=title      The title for the pull request. If unset, use the title
+                         of the commit message.
 
-  -url=url             GitHub API URL. If unset, use https://api.github.com.
+  -repository=repo       Repository to apply the patch to in 'owner/name' format.
+                         Required.
+
+  -token=token           GitHub API token with 'repo' scope for authentication.
+                         If unset, use the value of the GITHUB_TOKEN environment
+                         variable.
+
+  -url=url               GitHub API URL. If unset, use https://api.github.com.
 
 `
 	return strings.TrimSpace(help)

--- a/cmd/patch2pr/main.go
+++ b/cmd/patch2pr/main.go
@@ -340,6 +340,9 @@ func createFork(ctx context.Context, client *github.Client, fork, parent patch2p
 	if err != nil && !errors.As(err, &aerr) {
 		return err
 	}
+	if repo.GetFullName() != fork.String() {
+		return fmt.Errorf("fork of %q already exists at %q, cannot create %q", parent, repo.GetFullName(), fork)
+	}
 
 	// Poll the new repo until the default branch exists, indicating it is ready to use
 	ref := "heads/" + repo.GetDefaultBranch()

--- a/cmd/patch2pr/values.go
+++ b/cmd/patch2pr/values.go
@@ -49,3 +49,23 @@ func (v URLValue) Set(s string) error {
 	*v.u = u
 	return nil
 }
+
+type ForkValue struct {
+	RepositoryValue
+	enabled *bool
+}
+
+func (v ForkValue) String() string {
+	if v.enabled == nil || !*v.enabled {
+		return ""
+	}
+	return v.RepositoryValue.String()
+}
+
+func (v ForkValue) Set(s string) error {
+	if err := v.RepositoryValue.Set(s); err != nil {
+		return err
+	}
+	*v.enabled = true
+	return nil
+}


### PR DESCRIPTION
Add a new `-fork` flag to the CLI which will submit a pull request from a fork, creating it if it does not exist. This avoids needing write access on the target repository. Also add the `-fork-repository` flag, which sets a custom name and owner for the fork. The default is to create a fork with the same name as the target, owned by the current user.

Last, modify the error handler to print a hint on any 404 error that the problem might be due to permissions. It should maybe print the same message on 403 errors, but I haven't seen an example of that yet.

Closes #75.