### PR TITLE
Publish binaries with goreleaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,5 @@
 name: Go
+
 on:
   pull_request:
   push:
@@ -12,12 +13,12 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.20"
 
-      - name: Check out code into the Go module directory
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.20"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: v1.23.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/patch2pr
 .idea/
 
+/patch2pr
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+version: 1
+
+builds:
+  - main: ./cmd/patch2pr
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      # https://github.com/goreleaser/goreleaser/issues/602
+      - none*
+
+release:
+  mode: keep-existing

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ that uses this library to apply it and create a pull request.
 
 ## Usage: CLI
 
-Install the CLI using `go install`:
+Pre-built binaries for common platforms are available on the [releases][] page.
+
+You can also install from source using `go install`:
 
     go install github.com/bluekeyes/patch2pr/cmd/patch2pr@latest
 
@@ -38,6 +40,8 @@ For example:
     $ patch2pr -repository bluekeyes/patch2pr /path/to/file.patch
 
 See the CLI help (`-h` or `-help`) or below for full details.
+
+[releases]: https://github.com/bluekeyes/patch2pr/releases
 
 ### Full Usage
 


### PR DESCRIPTION
Use goreleaser to publish prebuilt binaries for various common platforms. Runs in GitHub Actions in response to publishing a new release, as opposed to pushing a new tag.

Closes #76.