### PR TITLE
support multiple patch files as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See the CLI help (`-h` or `-help`) or below for full details.
 ### Full Usage
 
 ```
-Usage: patch2pr [options] [patch]
+Usage: patch2pr [options] [patch...]
 
   Create a GitHub pull request from a patch file
 


### PR DESCRIPTION
this is a fairly simple rearrangement. we move some logic to a new parse() method to help with validating all patches before performing repository actions. 

the patches are applied in sequence, i.e. the "newCommit" of the first patch is used as the patch base of the next patch. 

this goes some way to helping with https://github.com/bluekeyes/patch2pr/issues/88. after this, there is a workaround by splitting and applying patches separately.

if this is not something you desire, it would be nice if an error was shown when multiple files are given.