### PR TITLE
Set language version to go1.23, build with go1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.60
+          version: v1.64
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluekeyes/patch2pr
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.8.1


### PR DESCRIPTION
go1.22 is no longer supported, which means newer versions of certain dependencies (`golang.org/x/net` right now) require 1.23 as the minimum version.