### PR TITLE
Make conflicts detectable with `errors.Is`

### DIFF
--- a/applier.go
+++ b/applier.go
@@ -91,7 +91,7 @@ func (a *Applier) applyCreate(ctx context.Context, f *gitdiff.File) (*github.Tre
 		return nil, err
 	}
 	if exists {
-		return nil, errors.New("existing entry for new file")
+		return nil, ErrNewFileAlreadyExists
 	}
 
 	c, err := base64Apply(nil, f)
@@ -119,7 +119,7 @@ func (a *Applier) applyDelete(ctx context.Context, f *gitdiff.File) (*github.Tre
 	if !exists {
 		// because the rest of application is strict, return an error if the
 		// file was already deleted, since it indicates a conflict of some kind
-		return nil, errors.New("missing entry for deleted file")
+		return nil, ErrNoSuchFileToDelete
 	}
 
 	data, _, err := a.client.Git.GetBlobRaw(ctx, a.owner, a.repo, entry.GetSHA())
@@ -128,7 +128,7 @@ func (a *Applier) applyDelete(ctx context.Context, f *gitdiff.File) (*github.Tre
 	}
 
 	if err := gitdiff.Apply(ioutil.Discard, bytes.NewReader(data), f); err != nil {
-		return nil, err
+		return nil, wrapGitdiffApplyError(err)
 	}
 
 	path := f.OldName
@@ -147,7 +147,7 @@ func (a *Applier) applyModify(ctx context.Context, f *gitdiff.File) (*github.Tre
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.New("no entry for modified file")
+		return nil, ErrNoSuchFileToModify
 	}
 
 	path := f.NewName
@@ -346,7 +346,7 @@ func base64Apply(data []byte, f *gitdiff.File) (string, error) {
 
 	enc := base64.NewEncoder(base64.StdEncoding, &b)
 	if err := gitdiff.Apply(enc, bytes.NewReader(data), f); err != nil {
-		return "", err
+		return "", wrapGitdiffApplyError(err)
 	}
 	if err := enc.Close(); err != nil {
 		return "", fmt.Errorf("base64 encoding failed: %w", err)

--- a/error.go
+++ b/error.go
@@ -3,7 +3,24 @@ package patch2pr
 import (
 	"errors"
 	"fmt"
+
+	"github.com/bluekeyes/go-gitdiff/gitdiff"
 )
+
+var (
+	ErrConflict = errors.New("conflict prevented applying patch")
+
+	ErrNewFileAlreadyExists = fmt.Errorf("%w: existing entry for new file", ErrConflict)
+	ErrNoSuchFileToDelete   = fmt.Errorf("%w: missing entry for deleted file", ErrConflict)
+	ErrNoSuchFileToModify   = fmt.Errorf("%w: no entry for modified file", ErrConflict)
+)
+
+func wrapGitdiffApplyError(err error) error {
+	if errors.Is(err, &gitdiff.Conflict{}) {
+		return fmt.Errorf("%w: gitdiff apply failed: %w", ErrConflict, err)
+	}
+	return fmt.Errorf("gitdiff apply failed: %w", err)
+}
 
 func unsupported(msg string, args ...any) error {
 	return unsupportedErr{reason: fmt.Sprintf(msg, args...)}

--- a/graphql_applier.go
+++ b/graphql_applier.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -122,12 +121,12 @@ func (a *GraphQLApplier) applyCreate(ctx context.Context, f *gitdiff.File) error
 		return err
 	}
 	if exists {
-		return errors.New("existing entry for new file")
+		return ErrNewFileAlreadyExists
 	}
 
 	var b bytes.Buffer
 	if err := gitdiff.Apply(&b, bytes.NewReader(nil), f); err != nil {
-		return err
+		return wrapGitdiffApplyError(err)
 	}
 
 	a.changes[f.NewName] = pendingChange{Content: b.Bytes()}
@@ -143,11 +142,11 @@ func (a *GraphQLApplier) applyDelete(ctx context.Context, f *gitdiff.File) error
 	if !exists {
 		// because the rest of application is strict, return an error if the
 		// file was already deleted, since it indicates a conflict of some kind
-		return errors.New("missing entry for deleted file")
+		return ErrNoSuchFileToDelete
 	}
 
 	if err := gitdiff.Apply(ioutil.Discard, bytes.NewReader(data), f); err != nil {
-		return err
+		return wrapGitdiffApplyError(err)
 	}
 
 	a.changes[f.OldName] = pendingChange{IsDelete: true}
@@ -160,13 +159,13 @@ func (a *GraphQLApplier) applyModify(ctx context.Context, f *gitdiff.File) error
 		return err
 	}
 	if !exists {
-		return errors.New("no entry for modified file")
+		return ErrNoSuchFileToModify
 	}
 
 	if len(f.TextFragments) > 0 || f.BinaryFragment != nil {
 		var b bytes.Buffer
 		if err := gitdiff.Apply(&b, bytes.NewReader(data), f); err != nil {
-			return err
+			return wrapGitdiffApplyError(err)
 		}
 		data = b.Bytes()
 	}


### PR DESCRIPTION
Currently, if there are file-level conflicts that prevent applying a patch, the caller only gets back an anonymous `error`, so they can't detect whether `Apply` failed due to a conflict or for some other reason.

This PR changes the error paths for file-level conflicts to return global sentinel errors, and also wraps content-level conflict errors (`gitdiff.Conflict`) in a sentinel error. With these changes, callers can detect conflicts like so:

```go
		_, err = applier.Apply(ctx, f)
		if err != nil {
			if errors.Is(err, patch2pr.ErrConflict) {
				// there's a conflict
			}
			// something else went wrong
		}
```

Not too attached to the exact implementation (message wording, error structure, …). Let me know if any of that should change, or feel free to push commits.

Thanks for making this library available!