### PR TITLE
Update google/go-github to v90

### DIFF
--- a/applier.go
+++ b/applier.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // DefaultCommitMessage is the commit message used when no message is provided

--- a/applier_test.go
+++ b/applier_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 	"github.com/bluekeyes/patch2pr/internal"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/shurcooL/githubv4"
 )
 

--- a/cmd/patch2pr/main.go
+++ b/cmd/patch2pr/main.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 
 	"github.com/bluekeyes/patch2pr"
 	"github.com/bluekeyes/patch2pr/internal"
@@ -288,17 +288,17 @@ func execute(ctx context.Context, client *github.Client, patchFiles []string, op
 			body = opts.PullBody
 		}
 
-		prSpec := &github.NewPullRequest{
+		prSpec := github.CreatePullRequest{
 			Title: &title,
 			Body:  &body,
-			Base:  &baseBranch,
+			Base:  baseBranch,
 			Draft: &opts.Draft,
 		}
 
 		if sourceRepo == targetRepo {
-			prSpec.Head = &headBranch
+			prSpec.Head = headBranch
 		} else {
-			prSpec.Head = github.Ptr(fmt.Sprintf("%s:%s", sourceRepo.Owner, headBranch))
+			prSpec.Head = fmt.Sprintf("%s:%s", sourceRepo.Owner, headBranch)
 			prSpec.HeadRepo = &sourceRepo.Name
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.9.0
-	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/v90 v90.0.0
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bluekeyes/go-gitdiff v0.9.0/go.mod h1:WWAk1Mc6EgWarCrPFO+xeYlujPu98Vu
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
-github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
+github.com/google/go-github/v90 v90.0.0 h1:EnX9HvTfqvuJbUSWu1/jLrYH6JJLMz0w0qfQVbTxPzE=
+github.com/google/go-github/v90 v90.0.0/go.mod h1:pLzt1FZURZyoTHT5/Z1UQY3b9fYyrbXH6aj7X+qgID4=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed h1:KT7hI8vYXgU0s2qaMkrfq9tCA1w/iEPgfredVP+4Tzw=

--- a/graphql_applier.go
+++ b/graphql_applier.go
@@ -10,7 +10,7 @@ import (
 	"path"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/shurcooL/githubv4"
 )
 

--- a/reference.go
+++ b/reference.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 )
 
 // Reference is a named reference in a repository.
@@ -69,15 +69,14 @@ func (r *Reference) Set(ctx context.Context, sha string, force bool) error {
 // PullRequest create a new pull request for the reference. The reference must
 // be a branch (start with "refs/heads/".) The pull request takes values from
 // spec, except for Head, which is set to the reference.
-func (r *Reference) PullRequest(ctx context.Context, spec *github.NewPullRequest) (*github.PullRequest, error) {
+func (r *Reference) PullRequest(ctx context.Context, spec github.CreatePullRequest) (*github.PullRequest, error) {
 	if !strings.HasPrefix(r.ref, "refs/heads/") {
 		return nil, fmt.Errorf("reference %s is not a branch", r.ref)
 	}
 
-	specCopy := *spec
-	specCopy.Head = github.Ptr(strings.TrimPrefix(r.ref, "refs/heads/"))
+	spec.Head = strings.TrimPrefix(r.ref, "refs/heads/")
 
-	pr, _, err := r.client.PullRequests.Create(ctx, r.owner, r.repo, &specCopy)
+	pr, _, err := r.client.PullRequests.Create(ctx, r.owner, r.repo, spec)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This requires a public API change as the `github.NewPullRequest` type no longer exists. The function that used this now takes the replacement `github.CreatePullRequest` value instead.